### PR TITLE
Lower minimum required VS Code version to 1.13.0 (May 2017)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "vscode": "^1.103.0"
+        "vscode": "^1.13.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": "^1.103.0"
+    "vscode": "^1.13.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR lowers the minimum required VS Code version to 1.13.0 (May 2017) so we won't see this error message when installing on older versions of VS Code:

> Can't install extension because it's not compatible with the current version of VSCode.