### PR TITLE
Move emoji data to `assets/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 - Fixed an issue where the incorrect emoji data path prevents all commands
-  from working in the published extension (#8).
+  from working in the published extension (#9).
 
 ## 0.2.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ written by John Gruber.
   - `loadEmojiData()`: Loads emoji codepoints from JSONL data file
   - `activate()`: Extension activation and command registration
   - Command handlers for stupefy and emoji removal operations
-- `src/emoji-data.jsonl`: Human-readable database of emoji codepoints from Unicode standard
+- `assets/emoji-data.jsonl`: Human-readable database of emoji codepoints from Unicode standard
 - `scripts/`: Build scripts for updating emoji data:
   - `update_emoji_data.sh`: Downloads latest Unicode emoji data
   - `parse-emoji-data.js`: Parses and filters emoji data into JSONL format
@@ -124,7 +124,7 @@ npm run watch-tests
    sh scripts/update_emoji_data.sh
    ```
 2. The script downloads and parses the latest emoji data from unicode.org
-3. Review the generated `src/emoji-data.jsonl` for accuracy
+3. Review the generated `assets/emoji-data.jsonl` for accuracy
 4. Rebuild the extension to include updated data
 
 ## File structure
@@ -133,7 +133,6 @@ npm run watch-tests
 /
 ├── src/
 │   ├── extension.ts           # Main extension code
-│   ├── emoji-data.jsonl       # Emoji codepoint database (human-readable)
 │   └── test/
 │       ├── extension.test.ts  # Unit and integration tests
 │       ├── runTest.ts         # Test runner entry point
@@ -142,10 +141,10 @@ npm run watch-tests
 ├── scripts/
 │   ├── update_emoji_data.sh   # Downloads latest Unicode emoji data
 │   └── parse-emoji-data.js    # Parses emoji data into JSONL format
+├── assets/
+│   ├── emoji-data.jsonl       # Emoji codepoint database (human-readable)
 ├── dist/
 │   ├── extension.js           # Bundled output
-│   └── src/
-│       └── emoji-data.jsonl   # Copied emoji data for runtime access
 ├── out/                       # Compiled test files (generated)
 ├── package.json               # Extension manifest and dependencies
 ├── tsconfig.json              # TypeScript configuration

--- a/assets/emoji-data.jsonl
+++ b/assets/emoji-data.jsonl
@@ -1,4 +1,4 @@
-{"_metadata":{"version":"2025-08-14T03:26:10.570Z","source":"https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-data.txt"}}
+{"_metadata":{"version":"2025-08-14T05:30:15.776Z","source":"https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-data.txt"}}
 {"range":["U+231A","U+231B"],"decimal":[8986,8987],"sample":"⌚⌛"}
 {"code":"U+2328","decimal":9000,"char":"⌨"}
 {"code":"U+23CF","decimal":9167,"char":"⏏"}

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,6 +1,4 @@
 const esbuild = require("esbuild");
-const fs = require("fs");
-const path = require("path");
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
@@ -25,30 +23,6 @@ const esbuildProblemMatcherPlugin = {
 	},
 };
 
-/**
- * @type {import('esbuild').Plugin}
- */
-const copyEmojiDataPlugin = {
-	name: 'copy-emoji-data',
-
-	setup(build) {
-		build.onEnd(() => {
-			// Copy emoji-data.jsonl to dist/src/
-			const srcPath = path.join(__dirname, 'src', 'emoji-data.jsonl');
-			const distDir = path.join(__dirname, 'dist', 'src');
-			const distPath = path.join(distDir, 'emoji-data.jsonl');
-
-			// Create dist/src directory if it doesn't exist
-			if (!fs.existsSync(distDir)) {
-				fs.mkdirSync(distDir, { recursive: true });
-			}
-
-			// Copy the file
-			fs.copyFileSync(srcPath, distPath);
-		});
-	},
-};
-
 async function main() {
 	const ctx = await esbuild.context({
 		entryPoints: [
@@ -64,7 +38,6 @@ async function main() {
 		external: ['vscode'],
 		logLevel: 'silent',
 		plugins: [
-			copyEmojiDataPlugin,
 			/* add to the end of plugins array */
 			esbuildProblemMatcherPlugin,
 		],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-stupefy",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-stupefy",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/scripts/update_emoji_data.sh
+++ b/scripts/update_emoji_data.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Download and parse Unicode emoji data
-# Output: src/emoji-data.jsonl with emoji codepoints in human-readable format
+# Output: assets/emoji-data.jsonl with emoji codepoints in human-readable format
 
 set -e
 
 EMOJI_DATA_URL="https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-data.txt"
 TEMP_FILE="emoji-data-temp.txt"
-OUTPUT_FILE="../src/emoji-data.jsonl"
+OUTPUT_FILE="../assets/emoji-data.jsonl"
 
 cd "$(dirname "$0")"
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4,12 +4,10 @@ import * as vscode from 'vscode';
 import { activate, removeEmoji, stupefyText } from '../extension';
 
 suite('Extension Test Suite', () => {
-	let mockContext: vscode.ExtensionContext;
-
 	// Initialize emoji data for tests
 	suiteSetup(() => {
 		// Create a mock context with the extension path
-		mockContext = {
+		const mockContext = {
 			subscriptions: [],
 			extensionPath: join(__dirname, '..', '..')
 		} as unknown as vscode.ExtensionContext;
@@ -165,122 +163,122 @@ suite('Extension Test Suite', () => {
 		test('should remove basic emoji faces', () => {
 			const input = 'Hello 😀 World 😊!';
 			const expected = 'Hello  World !';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should remove various emoji categories', () => {
 			const input = '⌚ Watch ⌨ Keyboard 🎅 Santa 🏂 Snowboard';
 			const expected = ' Watch  Keyboard  Santa  Snowboard';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should preserve ASCII characters like # and *', () => {
 			const input = '# Heading * List item ** Bold **';
 			const expected = '# Heading * List item ** Bold **';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should preserve digits 0-9', () => {
 			const input = '0123456789';
 			const expected = '0123456789';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should remove emoji but keep regular punctuation', () => {
 			const input = 'Hello! 👋 How are you? 🤔 I am fine. 😊';
 			const expected = 'Hello!  How are you?  I am fine. ';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should handle text with no emoji', () => {
 			const input = 'This is plain ASCII text with no emoji!';
 			const expected = 'This is plain ASCII text with no emoji!';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should handle empty string', () => {
-			strictEqual(removeEmoji('', mockContext), '');
+			strictEqual(removeEmoji(''), '');
 		});
 
 		test('should remove emoji at string boundaries', () => {
 			const input = '😀Start and End😀';
 			const expected = 'Start and End';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should remove consecutive emoji', () => {
 			const input = 'Multiple 😀😊😎 emoji';
 			const expected = 'Multiple  emoji';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should remove emoji from multiline text', () => {
 			const input = 'Line 1 😀\nLine 2 🎉\nLine 3 ✨';
 			const expected = 'Line 1 \nLine 2 \nLine 3 ';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should remove emoji flags', () => {
 			const input = 'USA 🇺🇸 France 🇫🇷 Japan 🇯🇵';
 			const expected = 'USA  France  Japan ';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should preserve copyright and trademark symbols when used as HTML entities', () => {
 			// These are not emoji when written as &copy; etc
 			const input = '&copy; 2024 &reg; &trade;';
 			const expected = '&copy; 2024 &reg; &trade;';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should remove heart and symbol emoji', () => {
 			// Note: ❤️ includes a variation selector which may not be fully removed
 			const input = 'I ❤ coding! ✅ Done ❌ Not done';
 			const expected = 'I  coding!  Done  Not done';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should handle mixed content with code blocks', () => {
 			const input = '```\ncode here\n```\n😊 Text with emoji';
 			const expected = '```\ncode here\n```\n Text with emoji';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should remove animal emoji', () => {
 			const input = '🐶 Dog 🐱 Cat 🦁 Lion';
 			const expected = ' Dog  Cat  Lion';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should remove food emoji', () => {
 			const input = '🍕 Pizza 🍔 Burger 🍎 Apple';
 			const expected = ' Pizza  Burger  Apple';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should handle surrogate pairs correctly', () => {
 			// Note: Family emoji with ZWJ sequences may leave some joiners
 			const input = 'Complex emoji: 👨👩👧👦 family';
 			const expected = 'Complex emoji:  family';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should preserve markdown formatting', () => {
 			const input = '**Bold** 😊 *Italic* 🎉 `code`';
 			const expected = '**Bold**  *Italic*  `code`';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should preserve URLs', () => {
 			const input = 'Visit https://example.com 😊 for more';
 			const expected = 'Visit https://example.com  for more';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 
 		test('should handle text with both smart punctuation and emoji', () => {
 			const input = '"Hello" — she said 😊';
 			const expected = '"Hello" — she said ';
-			strictEqual(removeEmoji(input, mockContext), expected);
+			strictEqual(removeEmoji(input), expected);
 		});
 	});
 


### PR DESCRIPTION
This PR reverts the major logic changes in #8 but apply a simple solution instead: move emoji data to `assets/` which will always exist in local development context or in the published extension.