### PR TITLE
Convert non-breaking hyphen (U+2011) to regular hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.2
+
+### Improvements
+
+- Convert non-breaking hyphens (U+2011) to regular hyphens in the
+  "Stupefy: Convert Smart Punctuation to ASCII" command (#14).
+
 ## 0.3.1
 
 ### Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-stupefy",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-stupefy",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-stupefy",
   "displayName": "Markdown Stupefy",
   "description": "Convert smart punctuation to ASCII and remove all emojis from Markdown",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "nanxstats",
   "author": {
     "name": "Nan Xiao"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import * as vscode from 'vscode';
 
 const STUPEFY_REPLACEMENTS: Map<string, string> = new Map([
+	['\u2011', '-'],         // non-breaking hyphen to regular hyphen
 	['\u2013', '--'],        // en-dash to double hyphen
 	['\u2014', '---'],       // em-dash to triple hyphen
 	['\u2018', "'"],         // left single quote to straight quote

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -16,6 +16,12 @@ suite('Extension Test Suite', () => {
 		activate(mockContext);
 	});
 	suite('stupefyText function', () => {
+		test('should convert non-breaking hyphen to regular hyphen', () => {
+			const input = 'non\u2011breaking hyphen';
+			const expected = 'non-breaking hyphen';
+			strictEqual(stupefyText(input), expected);
+		});
+
 		test('should convert en-dash to double hyphen', () => {
 			const input = 'Pages 10\u201320';
 			const expected = 'Pages 10--20';
@@ -115,6 +121,12 @@ suite('Extension Test Suite', () => {
 		test('should convert multiple smart characters in one string', () => {
 			const input = '\u201CIt\u2019s amazing\u201D\u2014she said\u2026';
 			const expected = '"It\'s amazing"---she said...';
+			strictEqual(stupefyText(input), expected);
+		});
+
+		test('should handle non-breaking hyphen with other smart punctuation', () => {
+			const input = '\u201Cnon\u2011breaking\u201D text\u2014here';
+			const expected = '"non-breaking" text---here';
 			strictEqual(stupefyText(input), expected);
 		});
 


### PR DESCRIPTION
This PR adds non-breaking hyphen (U+2011) to the conversion list for the stupefy command.

Also bumps the version number to 0.3.2 and updates the changelog.