### PR TITLE
Lower Node.js and TypeScript target to improve compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Maintenance
 
-- Updated TypeScript to ES2023 with NodeNext modules, raised web build target
-  to ES2022, and bumped dependency versions.
+- Update dependency versions (#25).
 - Replace `CLAUDE.md` with `AGENTS.md` (#22).
 
 ## 0.4.2

--- a/esbuild.js
+++ b/esbuild.js
@@ -31,6 +31,7 @@ async function main() {
 		],
 		bundle: true,
 		format: 'cjs',
+		target: 'node16',
 		minify: production,
 		sourcemap: !production,
 		sourcesContent: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
-        "@types/node": "22.x",
+        "@types/node": "16.x",
         "@types/vscode": "^1.78.0",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
@@ -870,14 +870,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.17.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
-      "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.102.0",
@@ -5643,13 +5640,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "@types/node": "22.x",
+    "@types/node": "16.x",
     "@types/vscode": "^1.78.0",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
 	"compilerOptions": {
 		"module": "NodeNext",
-		"target": "ES2023",
+		"target": "ES2020",
 		"lib": [
-			"ES2023"
+			"ES2020"
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true,   /* enable all strict type-checking options */
+		"strict": true, /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
This PR partially reverts the changes made in https://github.com/nanxstats/vscode-markdown-stupefy/commit/48b5ab20ac7d2c0a64e80089587a3416b988b00b and https://github.com/nanxstats/vscode-markdown-stupefy/commit/cb57106313347479d774abb72370a9419cea6860 for better backwards compatibility.