### PR TITLE
Convert two-em dash/three-em dash/bullet to ASCII equivalents

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,10 +5,13 @@ const STUPEFY_REPLACEMENTS: Map<string, string> = new Map([
 	['\u2011', '-'],         // non-breaking hyphen to regular hyphen
 	['\u2013', '--'],        // en-dash to double hyphen
 	['\u2014', '---'],       // em-dash to triple hyphen
+	['\u2E3A', '------'],    // two-em dash to six hyphens
+	['\u2E3B', '---------'], // three-em dash to nine hyphens
 	['\u2018', "'"],         // left single quote to straight quote
 	['\u2019', "'"],         // right single quote to straight quote
 	['\u201C', '"'],         // left double quote to straight quote
 	['\u201D', '"'],         // right double quote to straight quote
+	['\u2022', '-'],         // bullet to hyphen
 	['\u2026', '...'],       // ellipsis to three dots
 	['\u00AB', '<<'],        // left-pointing double angle quotation mark to <<
 	['\u00BB', '>>'],        // right-pointing double angle quotation mark to >>

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -33,6 +33,18 @@ suite('Extension Test Suite', () => {
 			strictEqual(stupefyText(input), expected);
 		});
 
+		test('should convert two-em dash to six hyphens', () => {
+			const input = 'Author \u2E3A Title';
+			const expected = 'Author ------ Title';
+			strictEqual(stupefyText(input), expected);
+		});
+
+		test('should convert three-em dash to nine hyphens', () => {
+			const input = 'Author \u2E3B. Title';
+			const expected = 'Author ---------. Title';
+			strictEqual(stupefyText(input), expected);
+		});
+
 		test('should convert left single quote to straight quote', () => {
 			const input = '\u2018Hello world';
 			const expected = '\'Hello world';
@@ -54,6 +66,12 @@ suite('Extension Test Suite', () => {
 		test('should convert right double quote to straight quote', () => {
 			const input = 'Hello world\u201D';
 			const expected = 'Hello world"';
+			strictEqual(stupefyText(input), expected);
+		});
+
+		test('should convert bullet to hyphen', () => {
+			const input = '\u2022 Item';
+			const expected = '- Item';
 			strictEqual(stupefyText(input), expected);
 		});
 


### PR DESCRIPTION
This PR extends the `stupefyText` command by converting additional Unicode characters to their ASCII equivalents:

- Two-em dash (`\u2E3A`) to six hyphens.
- Three-em dash (`\u2E3B`) to nine hyphens.
- Bullet character (`\u2022`) to a hyphen.

Also adds corresponding tests.