### PR TITLE
Remove object replacement character

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ const STUPEFY_REPLACEMENTS: Map<string, string> = new Map([
 	['\u00B0', '&deg;'],     // degree symbol to &deg;
 	['\u00B1', '&plusmn;'],  // plus-minus sign to &plusmn;
 	['\u2122', '&trade;'],   // trademark symbol to &trade;
+	['\uFFFC', ''],          // object replacement character to empty string
 ]);
 
 export function stupefyText(text: string): string {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -147,6 +147,18 @@ suite('Extension Test Suite', () => {
 			strictEqual(stupefyText(input), expected);
 		});
 
+		test('should remove object replacement character (U+FFFC)', () => {
+			const input = 'See \uFFFC reference';
+			const expected = 'See  reference';
+			strictEqual(stupefyText(input), expected);
+		});
+
+		test('should remove multiple object replacement characters', () => {
+			const input = 'a\uFFFCb\uFFFCc';
+			const expected = 'abc';
+			strictEqual(stupefyText(input), expected);
+		});
+
 		test('should convert multiple smart characters in one string', () => {
 			const input = '\u201CIt\u2019s amazing\u201D\u2014she said\u2026';
 			const expected = '"It\'s amazing"---she said...';


### PR DESCRIPTION
This PR updates the character replacement logic in the `stupefyText` command to replace the Unicode object replacement character (`U+FFFC`) with an empty string.

This character often appears when copying the LLM response as Markdown where there are end-of-paragraph references to web pages.