### PR TITLE
Release vscode-markdown-stupefy 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.0
+
+### Improvements
+
+- Added support for converting two-em dash (`U+2E3A`), three-em dash (`U+2E3B`),
+  and bullet (`U+2022`) to their ASCII equivalents (#26).
+  Remove the object replacement character (`U+FFFC`) (#28).
+
 ## 0.4.3
 
 ### Maintenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-stupefy",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-stupefy",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-stupefy",
   "displayName": "Markdown Stupefy",
   "description": "Convert smart punctuation to ASCII and remove all emojis from Markdown",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "publisher": "nanxstats",
   "author": {
     "name": "Nan Xiao"


### PR DESCRIPTION
This PR updates the changelog and bumps the version number to 0.5.0.