### PR TITLE
Release vscode-markdown-stupefy 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.1
+
+### Maintenance
+
+- Added script `scripts/banner.sh` to generate the README banner image (#31).
+- Refined `@types/node` version range (replacing `16.x`) for consistency and
+  upgraded `@typescript-eslint/*` packages (#30).
+
 ## 0.5.0
 
 ### Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-stupefy",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-stupefy",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-stupefy",
   "displayName": "Markdown Stupefy",
   "description": "Convert smart punctuation to ASCII and remove all emojis from Markdown",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "nanxstats",
   "author": {
     "name": "Nan Xiao"


### PR DESCRIPTION
This PR updates the changelog and bumps the version number to 0.5.1.