### PR TITLE
Convert non-breaking spaces to regular spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 0.6.0
 
+### Improvements
+
+- Added support for converting non-breaking spaces (`U+00A0`) to regular spaces (#42).
+
 ### Maintenance
 
-Updated development dependencies to the latest compatible versions (#41), including:
+Updated development dependencies to the latest compatible versions (#41):
 
 - `@typescript-eslint/eslint-plugin` 8.46.1 -> 8.46.2
 - `@typescript-eslint/parser` 8.46.1 -> 8.46.2

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ const STUPEFY_REPLACEMENTS: Map<string, string> = new Map([
 	['\u201D', '"'],         // right double quote to straight quote
 	['\u2022', '-'],         // bullet to hyphen
 	['\u2026', '...'],       // ellipsis to three dots
+	['\u00A0', ' '],         // non-breaking space to regular space
 	['\u00AB', '<<'],        // left-pointing double angle quotation mark to <<
 	['\u00BB', '>>'],        // right-pointing double angle quotation mark to >>
 	['\u2190', '<-'],        // left arrow to ASCII arrow

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -81,6 +81,12 @@ suite('Extension Test Suite', () => {
 			strictEqual(stupefyText(input), expected);
 		});
 
+		test('should convert non-breaking space to regular space', () => {
+			const input = 'Hello\u00A0World';
+			const expected = 'Hello World';
+			strictEqual(stupefyText(input), expected);
+		});
+
 		test('should convert left-pointing double angle quotation mark to <<', () => {
 			const input = '\u00ABQuote\u00BB';
 			const expected = '<<Quote>>';


### PR DESCRIPTION
This PR added a rule to convert non-breaking spaces (`U+00A0`, which appears sometimes) to regular spaces.