### PR TITLE
Release vscode-markdown-stupefy 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-stupefy",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-stupefy",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-stupefy",
   "displayName": "Markdown Stupefy",
   "description": "Convert smart punctuation to ASCII and remove all emojis from Markdown",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "publisher": "nanxstats",
   "author": {
     "name": "Nan Xiao"


### PR DESCRIPTION
This PR bumps the version number to 0.6.0. Changelog is already up-to-date.